### PR TITLE
fix: global tags for vwan resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ End-to-end testing is not conducted on these modules, as they are individual com
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.61 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.61 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.3 |
 
 ## Resources
 
@@ -63,6 +63,7 @@ End-to-end testing is not conducted on these modules, as they are individual com
 | `naming` | contains naming convention | string | yes |
 | `location` | default azure region and can be used if location is not specified inside the object | string | no |
 | `resource_group` | default resource group and can be used if resourcegroup is not specified inside the object | string | no |
+| `tags` | tags to be added to the resources | map(string) | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "azurerm_virtual_wan" "vwan" {
   disable_vpn_encryption            = try(var.vwan.disable_vpn_encryption, false)
   type                              = try(var.vwan.type, "Standard")
   office365_local_breakout_category = try(var.vwan.office365_local_breakout_category, "None")
-  tags                              = try(var.vwan.tags, {})
+  tags                              = try(var.vwan.tags, var.tags)
 }
 
 # vhubs
@@ -23,7 +23,7 @@ resource "azurerm_virtual_hub" "vhub" {
   virtual_wan_id         = azurerm_virtual_wan.vwan.id
   sku                    = try(each.value.sku, "Standard")
   hub_routing_preference = try(each.value.hub_routing_preference, "ExpressRoute")
-  tags                   = try(each.value.tags, {})
+  tags                   = try(each.value.tags, var.tags)
 }
 
 # vpn gateway
@@ -37,7 +37,7 @@ resource "azurerm_vpn_gateway" "vpn_gateway" {
   location            = coalesce(lookup(each.value, "location", null), var.location)
   virtual_hub_id      = azurerm_virtual_hub.vhub[each.key].id
   routing_preference  = lookup(each.value.vpn_gateway, "routing_preference", null)
-  tags                = try(var.vwan.tags, {})
+  tags                = try(var.vwan.tags, var.tags)
 }
 
 # vpn sites
@@ -61,7 +61,7 @@ resource "azurerm_vpn_site" "vpn_site" {
   address_cidrs       = [each.value.address_prefix]
   device_vendor       = try(each.value.device_vendor, "Microsoft")
   device_model        = try(each.value.device_model, "VpnSite")
-  tags                = try(var.vwan.tags, {})
+  tags                = try(var.vwan.tags, var.tags)
 
   dynamic "link" {
     # minimal of one link is required

--- a/variables.tf
+++ b/variables.tf
@@ -20,3 +20,9 @@ variable "resource_group" {
   type        = string
   default     = null
 }
+
+variable "tags" {
+  description = "default tags to be used."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Description

* Added possibility for generic tags for all resources created in the vwan module
* Updated README with new azurerm version

## PR Checklist

- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

* Added possibility for generic tags for all resources created in the vwan module
* Updated README with new azurerm version

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)