### PR TITLE
fix: remove non existing gateway_ip vpn sites in type definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ object({
         vpn_sites = optional(map(object({
           name           = optional(string)
           address_prefix = string
-          gateway_ip     = string
           device_vendor  = optional(string, "Microsoft")
           device_model   = optional(string, "VpnSite")
           o365_policy = optional(object({

--- a/variables.tf
+++ b/variables.tf
@@ -99,7 +99,6 @@ variable "vwan" {
         vpn_sites = optional(map(object({
           name           = optional(string)
           address_prefix = string
-          gateway_ip     = string
           device_vendor  = optional(string, "Microsoft")
           device_model   = optional(string, "VpnSite")
           o365_policy = optional(object({


### PR DESCRIPTION
## Description

This PR removes non existing gateway_ip vpn sites in type definition

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #0000
