### PR TITLE
fix: remove vpn link validation condition

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -204,12 +204,13 @@ variable "vwan" {
   }
 
   validation {
-    condition = can(flatten([
-      for vhub_key, vhub in var.vwan.vhubs : [
-        for site_key, site in vhub.site_to_site_vpn.vpn_sites : [
-          for conn_key, conn in site.connections : [
-            for conn_link_key, conn_link in conn.vpn_links :
-            regex("^${coalesce(site.vpn_links[conn_link_key].name, conn_link_key)}$", coalesce(conn_link.name, conn_link_key))
+    condition = alltrue(flatten([
+      for vhub in var.vwan.vhubs : [
+        for site in try(vhub.site_to_site_vpn.vpn_sites, {}) : [
+          for conn in try(site.connections, {}) : [
+            for conn_link_key, conn_link in try(conn.vpn_links, {}) : [
+              coalesce(site.vpn_links[conn_link_key].name, conn_link_key) == coalesce(conn_link.name, conn_link_key)
+            ]
           ]
         ]
       ]

--- a/variables.tf
+++ b/variables.tf
@@ -202,21 +202,6 @@ variable "vwan" {
     condition     = var.vwan.resource_group_name != null || var.resource_group_name != null
     error_message = "resource group name must be provided either in the object or as a separate variable."
   }
-
-  validation {
-    condition = alltrue(flatten([
-      for vhub in var.vwan.vhubs : [
-        for site in try(vhub.site_to_site_vpn.vpn_sites, {}) : [
-          for conn in try(site.connections, {}) : [
-            for conn_link_key, conn_link in try(conn.vpn_links, {}) : [
-              try(coalesce(site.vpn_links[conn_link_key].name, conn_link_key), conn_link_key) == try(coalesce(conn_link.name, conn_link_key), conn_link_key)
-            ]
-          ]
-        ]
-      ]
-    ]))
-    error_message = "vpn_link names must match exactly between site and connection"
-  }
 }
 
 variable "naming" {

--- a/variables.tf
+++ b/variables.tf
@@ -209,7 +209,7 @@ variable "vwan" {
         for site in try(vhub.site_to_site_vpn.vpn_sites, {}) : [
           for conn in try(site.connections, {}) : [
             for conn_link_key, conn_link in try(conn.vpn_links, {}) : [
-              coalesce(site.vpn_links[conn_link_key].name, conn_link_key) == coalesce(conn_link.name, conn_link_key)
+              try(coalesce(site.vpn_links[conn_link_key].name, conn_link_key), conn_link_key) == try(coalesce(conn_link.name, conn_link_key), conn_link_key)
             ]
           ]
         ]


### PR DESCRIPTION
## Description

The original validation logic failed if multiple vhubs were configured and one of them did not contain a site_to_site_vpn definition.

Configuration example which produced an error:
```
    vhubs = {
      centralus = {
        name           = module.naming-centralus.virtual_hub.name
        location       = "centralus"
        address_prefix = "10.20.0.0/24"
        sku            = "Standard"
        site_to_site_vpn = {
          name = "beta"
          vpn_sites = {
            beta = {
              address_cidrs = ["10.10.0.0/16"]
              vpn_links = {
                beta = {
                  ip_address    = "185.12.183.200"
                  speed_in_mbps = 100
                }
              }
              connections = {
                beta = {
                  shared_key            = "xxx"
                  connection_type       = "IPsec"
                  local_address_ranges  = ["10.20.0.0/24"]
                  remote_address_ranges = ["10.10.0.0/16"]
                  vpn_links = {
                    beta = {
                      shared_key = "xxx"
                      protocol   = "IKEv2"
                      ipsec_policy = {
                        beta = {
                          pfs_group                = "PFS14"
                          dh_group                 = "DHGroup14"
                          sa_data_size_kb          = 10000
                          sa_lifetime_sec          = 3600
                          ike_integrity_algorithm  = "SHA256"
                          ike_encryption_algorithm = "AES256"
                          integrity_algorithm      = "SHA256"
                          encryption_algorithm     = "AES256"
                        }
                      }
                    }
                  }
                }
              }
            }
          }
        }
      }

      eastus2 = {
        name                = module.naming-eastus2.virtual_hub.name
        resource_group_name = module.rg.groups.demo-eastus2.name
        location            = "eastus2"
        address_prefix      = "10.21.0.0/24"
        sku                 = "Standard"
      }
    }
```

Would produce the error `vpn_link names must match exactly between site and connection`.

The  validation logic was tested with both correct and incorrect values:
* Unset `name` variable using `vpn_links.key`
* Set `name` variable
* One `name` variable being set and the other unset

## PR Checklist

- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have made corresponding changes to the documentation
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [X] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * vpn_links validation - Fix validation if site_to_site_vpn is not set in a vhub.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)
