### PR TITLE
fix: remove explicit depends_on 

### DIFF
--- a/examples/vhub-connection/main.tf
+++ b/examples/vhub-connection/main.tf
@@ -101,5 +101,4 @@ module "vhub-connection" {
       }
     }
   }
-  depends_on = [module.vwan]
 }


### PR DESCRIPTION
## Description

Removed explicit depends_on in the example to avoid recreation of vhub connections on an in-place update. 
With depends_on = [module.vwan]:
Adding depends_on forces Terraform to wait for the entire module.vwan to be finished, including any in-place updates or metadata changes, even if those changes are completely unrelated to the vHub or its outputs.
This is what triggers the warning:
# (depends on a resource or a module with changes pending)
And because the data source inside module.vhub-connection (data.azurerm_virtual_hub.vhub) depends on that vHub, and now Terraform sees it as “not yet known” (values become known after apply), it treats it as changed, which invalidates the current state of the dependent resources like azurerm_virtual_hub_connection.
As a result, Terraform forces a recreate (replace) of the hub connection, even though the vHub wasn’t structurally changed.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_resource` - support for the `example` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #114 
