### PR TITLE
feat: add support for using different resourcegroups for vpn gateways and expressroute

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ object({
       }))
       site_to_site_vpn = optional(object({
         name                                  = string
+        resource_group_name                   = optional(string, null)
         routing_preference                    = optional(string, null)
         bgp_route_translation_for_nat_enabled = optional(bool, false)
         scale_unit                            = optional(number, 1)
@@ -206,7 +207,7 @@ object({
             })), {})
             vpn_links = map(object({
               name                                  = optional(string)
-              shared_key                            = string
+              shared_key                            = optional(string, null)
               bgp_enabled                           = optional(bool, false)
               protocol                              = optional(string, "IKEv2")
               ingress_nat_rule_ids                  = optional(list(string), [])
@@ -252,6 +253,7 @@ object({
       }), null)
       express_route_gateway = optional(object({
         name                          = optional(string)
+        resource_group_name           = optional(string, null)
         scale_units                   = number
         allow_non_virtual_wan_traffic = optional(bool, false)
       }))

--- a/main.tf
+++ b/main.tf
@@ -248,7 +248,6 @@ resource "azurerm_point_to_site_vpn_gateway" "p2s_gateway" {
   }
 }
 
-# site to site vpn gatewayP
 resource "azurerm_vpn_gateway" "vpn_gateway" {
   for_each = nonsensitive({
     for k, v in lookup(var.vwan, "vhubs", {}) : k => v
@@ -259,8 +258,12 @@ resource "azurerm_vpn_gateway" "vpn_gateway" {
 
   resource_group_name = coalesce(
     lookup(
+      lookup(each.value, "site_to_site_vpn", {}), "resource_group_name", null
+    ),
+    lookup(
       var.vwan, "resource_group_name", null
-    ), var.resource_group_name
+    ),
+    var.resource_group_name
   )
 
   location = coalesce(
@@ -564,8 +567,13 @@ resource "azurerm_express_route_gateway" "er_gateway" {
   })
 
   resource_group_name = coalesce(
-    lookup(var.vwan, "resource_group_name", null
-    ), var.resource_group_name
+    lookup(
+      lookup(each.value, "express_route_gateway", {}), "resource_group_name", null
+    ),
+    lookup(
+      var.vwan, "resource_group_name", null
+    ),
+    var.resource_group_name
   )
 
   location = coalesce(

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,7 @@ variable "vwan" {
       }))
       site_to_site_vpn = optional(object({
         name                                  = string
+        resource_group_name                   = optional(string, null)
         routing_preference                    = optional(string, null)
         bgp_route_translation_for_nat_enabled = optional(bool, false)
         scale_unit                            = optional(number, 1)
@@ -137,7 +138,7 @@ variable "vwan" {
             })), {})
             vpn_links = map(object({
               name                                  = optional(string)
-              shared_key                            = string
+              shared_key                            = optional(string, null)
               bgp_enabled                           = optional(bool, false)
               protocol                              = optional(string, "IKEv2")
               ingress_nat_rule_ids                  = optional(list(string), [])
@@ -183,6 +184,7 @@ variable "vwan" {
       }), null)
       express_route_gateway = optional(object({
         name                          = optional(string)
+        resource_group_name           = optional(string, null)
         scale_units                   = number
         allow_non_virtual_wan_traffic = optional(bool, false)
       }))


### PR DESCRIPTION
## Description

This PR adds resource_group_name support for individual vpn gateways and expressroute

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)