### PR TITLE
feat: add support for using different resourcegroups for virtual hubs as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ object({
     tags                              = optional(map(string))
     vhubs = optional(map(object({
       name                                   = optional(string)
+      resource_group_name                    = optional(string, null)
       location                               = optional(string, null)
       address_prefix                         = string
       sku                                    = optional(string, "Standard")

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,9 @@ resource "azurerm_virtual_hub" "vhub" {
 
   resource_group_name = coalesce(
     lookup(
+      each.value, "resource_group_name", null
+    ),
+    lookup(
       var.vwan, "resource_group_name", null
     ), var.resource_group_name
   )

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,7 @@ variable "vwan" {
     tags                              = optional(map(string))
     vhubs = optional(map(object({
       name                                   = optional(string)
+      resource_group_name                    = optional(string, null)
       location                               = optional(string, null)
       address_prefix                         = string
       sku                                    = optional(string, "Standard")


### PR DESCRIPTION
## Description

This PR add support for using different resourcegroups for virtual hubs as well

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)