### PR TITLE
fix bgp settings to be able to keep the default asn 65515

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -92,8 +92,8 @@ variable "vwan" {
         scale_unit                            = optional(number, 1)
         tags                                  = optional(map(string))
         bgp_settings = optional(object({
-          asn         = number
-          peer_weight = number
+          asn         = optional(number, 65515)
+          peer_weight = optional(number, 0)
           instance_0_bgp_peering_address = optional(object({
             custom_ips = list(string)
           }))
@@ -298,9 +298,9 @@ variable "vwan" {
     condition = alltrue([
       for hub_key, hub in var.vwan.vhubs :
       hub.site_to_site_vpn == null || hub.site_to_site_vpn.bgp_settings == null ||
-      (hub.site_to_site_vpn.bgp_settings.asn >= 1 && hub.site_to_site_vpn.bgp_settings.asn <= 4294967295 && hub.site_to_site_vpn.bgp_settings.asn != 65515)
+      (hub.site_to_site_vpn.bgp_settings.asn >= 1 && hub.site_to_site_vpn.bgp_settings.asn <= 4294967295)
     ])
-    error_message = "BGP ASN must be between 1 and 4294967295, and cannot be 65515 (reserved by Azure)."
+    error_message = "BGP ASN must be between 1 and 4294967295."
   }
 
   validation {


### PR DESCRIPTION
## Description

Think we should be able to set/keep the asn in azure to the default 65515 in bgp settings
This setting is set to 65515 by default in azure so we should be able to keep that the same when using this module
Now if we want to set bgp settings the asn needs to be  changed other than the default and causes recreation of the whole resource

## PR Checklist

- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_resource` - support for the `example` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #0000
