### PR TITLE
fix: validation rule update allowing bgp asn 65515

### DIFF
--- a/examples/vpn-bgp-peering/main.tf
+++ b/examples/vpn-bgp-peering/main.tf
@@ -40,7 +40,8 @@ module "kv" {
 }
 
 module "vwan" {
-  source = "../../"
+  source  = "cloudnationhq/vwan/azure"
+  version = "~> 6.0"
 
   naming              = local.naming
   location            = module.rg.groups.demo.location

--- a/examples/vpn-bgp-peering/main.tf
+++ b/examples/vpn-bgp-peering/main.tf
@@ -1,0 +1,55 @@
+module "naming" {
+  source  = "cloudnationhq/naming/azure"
+  version = "~> 0.24"
+
+  suffix = ["demo", "dev"]
+}
+
+module "rg" {
+  source  = "cloudnationhq/rg/azure"
+  version = "~> 2.0"
+
+  groups = {
+    demo = {
+      name     = module.naming.resource_group.name_unique
+      location = "westeurope"
+    }
+  }
+}
+
+module "kv" {
+  source  = "CloudNationHQ/kv/azure"
+  version = "~> 4.0"
+
+  vault = {
+    name                = module.naming.key_vault.name_unique
+    location            = module.rg.groups.demo.location
+    resource_group_name = module.rg.groups.demo.name
+
+    secrets = {
+      random_string = {
+        psk = {
+          length      = 32
+          special     = false
+          min_special = 0
+          min_upper   = 2
+        }
+      }
+    }
+  }
+}
+
+module "vwan" {
+  source = "../../"
+
+  naming              = local.naming
+  location            = module.rg.groups.demo.location
+  resource_group_name = module.rg.groups.demo.name
+
+  vwan = {
+    name                           = module.naming.virtual_wan.name
+    vhubs                          = local.vhubs
+    allow_branch_to_branch_traffic = true
+    disable_vpn_encryption         = false
+  }
+}

--- a/examples/vpn-bgp-peering/naming.tf
+++ b/examples/vpn-bgp-peering/naming.tf
@@ -1,0 +1,7 @@
+locals {
+  naming = {
+    for type in local.naming_types : type => lookup(module.naming, type).name
+  }
+
+  naming_types = ["virtual_hub", "vpn_site", "vpn_gateway_connection"]
+}

--- a/examples/vpn-bgp-peering/terraform.tf
+++ b/examples/vpn-bgp-peering/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/examples/vpn-bgp-peering/vhubs.tf
+++ b/examples/vpn-bgp-peering/vhubs.tf
@@ -1,0 +1,83 @@
+locals {
+  vhubs = {
+    weu = {
+      location       = "westeurope"
+      address_prefix = "10.0.0.0/23"
+
+      site_to_site_vpn = {
+        name = "weu-s2s-gateway"
+
+        # Gateway-level BGP configuration.
+        # custom_ips contains only the Azure-side APIPA addresses, one per gateway instance.
+        # On-premise APIPA addresses are set per VPN site link via bgp.peering_address below.
+        bgp_settings = {
+          asn         = 65515
+          peer_weight = 0
+          instance_0_bgp_peering_address = {
+            custom_ips = ["169.254.21.1"]
+          }
+          instance_1_bgp_peering_address = {
+            custom_ips = ["169.254.22.1"]
+          }
+        }
+
+        vpn_sites = {
+          # On-premise datacenter 1
+          # One link per physical device — Azure creates two tunnels automatically
+          dc1 = {
+            address_cidrs = ["192.168.1.0/24"]
+            vpn_links = {
+              link1 = {
+                ip_address    = "203.0.113.1"
+                provider_name = "ISP1"
+                speed_in_mbps = 100
+                bgp = {
+                  peering_address = "169.254.21.2"
+                  asn             = 64512
+                }
+              }
+            }
+            connections = {
+              connection1 = {
+                vpn_links = {
+                  link1 = {
+                    shared_key  = module.kv.secrets.psk.value
+                    bgp_enabled = true
+                    protocol    = "IKEv2"
+                  }
+                }
+              }
+            }
+          }
+
+          # On-premise datacenter 2
+          dc2 = {
+            address_cidrs = ["192.168.2.0/24"]
+            vpn_links = {
+              link1 = {
+                ip_address    = "203.0.114.1"
+                provider_name = "ISP1"
+                speed_in_mbps = 100
+                bgp = {
+                  peering_address = "169.254.21.6"
+                  asn             = 64513
+                }
+              }
+            }
+            connections = {
+              connection1 = {
+                vpn_links = {
+                  link1 = {
+                    shared_key  = module.kv.secrets.psk.value
+                    bgp_enabled = true
+                    protocol    = "IKEv2"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -299,9 +299,9 @@ variable "vwan" {
     condition = alltrue([
       for hub_key, hub in var.vwan.vhubs :
       hub.site_to_site_vpn == null || hub.site_to_site_vpn.bgp_settings == null ||
-      (hub.site_to_site_vpn.bgp_settings.asn >= 1 && hub.site_to_site_vpn.bgp_settings.asn <= 4294967295 && hub.site_to_site_vpn.bgp_settings.asn != 65515)
+      (hub.site_to_site_vpn.bgp_settings.asn >= 1 && hub.site_to_site_vpn.bgp_settings.asn <= 4294967295)
     ])
-    error_message = "BGP ASN must be between 1 and 4294967295, and cannot be 65515 (reserved by Azure)."
+    error_message = "BGP ASN must be between 1 and 4294967295."
   }
 
   validation {


### PR DESCRIPTION


## Description

- updated validation rule allowing bgp asn 65515
- added full example for bgp peering

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #148 
